### PR TITLE
Fix getReviewSummary so that review summary shows the correct stars

### DIFF
--- a/database/methods/reviewsummary.js
+++ b/database/methods/reviewsummary.js
@@ -16,10 +16,12 @@ const getReviewSummary = (product, cb) => {
       console.log('PROBLEM GETTING THE REQUESTED REVIEWS: ', err);
     } else {
       summary[0].total_reviews = res.rows.length;
-      for (let i = 0; i < res.rows; i++) {
-        let rating = res.rows[i].review_rating;
-        summary[0][`rating_${rating}`] += 1;
-      }
+      summary[0].rating_1 = res.rows.filter(review => review.review_rating === 1).length;
+      summary[0].rating_2 = res.rows.filter(review => review.review_rating === 2).length;
+      summary[0].rating_3 = res.rows.filter(review => review.review_rating === 3).length;
+      summary[0].rating_4 = res.rows.filter(review => review.review_rating === 4).length;
+      summary[0].rating_5 = res.rows.filter(review => review.review_rating === 5).length;
+      console.log('RETURNED SUMMARY: ', summary);
       cb(null, summary);
     }
   })


### PR DESCRIPTION
Opened page in browser to confirm it was displaying properly as sometimes no error is thrown, but the page would not display anything either.  Page currently displays the correct overall review summary.  This was accomplished by removing the for loop which was supposed to assign ratings for the summary and replacing it with filter for each rating.