### PR TITLE
Add more phases to Artillery tests and increase arrival rates

### DIFF
--- a/review_test.yml
+++ b/review_test.yml
@@ -2,8 +2,15 @@ config:
   target: "http://localhost:3001"
   phases:
     - duration: 60
-      arrivalRate: 1
+      arrivalRate: 10
       name: Warm up
+    - duration: 120
+      arrivalRate: 10
+      rampTo: 50
+      name: Ramp up load
+    - duration: 600
+      arrivalRate: 50
+      name: Sustained Load
   variables:
     product_id:
       - "1"


### PR DESCRIPTION
Added ramp up and sustained load phases to the Artillery tests and increased virtual users from a starting point of 10 to a final and sustained point of 50.